### PR TITLE
Story 3 Login/Register backend endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -39,10 +39,12 @@
         "@types/node": "^14.14.14",
         "@types/node-fetch": "^2.5.8",
         "@types/node-schedule": "^1.3.1",
+        "@types/supertest": "^6.0.2",
         "babel-jest": "^29.7.0",
         "jest": "^29.7.0",
         "mongodb-memory-server": "^10.1.2",
         "nodemon": "^2.0.6",
+        "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.6.3"
@@ -2434,6 +2436,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/cors": {
       "version": "2.8.17",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
@@ -2530,6 +2538,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -2631,6 +2645,28 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -2841,6 +2877,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -3481,6 +3523,15 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3542,6 +3593,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/core-js-compat": {
       "version": "3.39.0",
@@ -3749,6 +3806,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dicer": {
@@ -4059,6 +4126,12 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -4189,6 +4262,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4447,6 +4534,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/html-escaper": {
@@ -7277,6 +7373,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,10 +42,12 @@
     "@types/node": "^14.14.14",
     "@types/node-fetch": "^2.5.8",
     "@types/node-schedule": "^1.3.1",
+    "@types/supertest": "^6.0.2",
     "babel-jest": "^29.7.0",
     "jest": "^29.7.0",
     "mongodb-memory-server": "^10.1.2",
     "nodemon": "^2.0.6",
+    "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/backend/src/api/__tests__/user.test.ts
+++ b/backend/src/api/__tests__/user.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import router from '../router';
+import { register, login } from '../../controller/user';
+
+jest.mock('../../controller/user');
+
+const mockedRegister = register as jest.Mock;
+const mockedLogin = login as jest.Mock;
+
+describe('User Routes', () => {
+  let app: Express;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/', router());
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call register controller on POST /register', async () => {
+    mockedRegister.mockImplementation((req, res) => {
+      res.status(201).send({ message: 'User registered' });
+    });
+
+    const response = await request(app)
+      .post('/register')
+      .send({ username: 'testuser', password: 'testpass' });
+
+    expect(mockedRegister).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({ message: 'User registered' });
+  });
+
+  it('should call login controller on POST /login', async () => {
+    mockedLogin.mockImplementation((req, res) => {
+      res.status(200).send({ token: 'fake-jwt-token' });
+    });
+
+    const response = await request(app)
+      .post('/login')
+      .send({ username: 'testuser', password: 'testpass' });
+
+    expect(mockedLogin).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ token: 'fake-jwt-token' });
+  });
+});

--- a/backend/src/api/router.ts
+++ b/backend/src/api/router.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import user from "./routes/user";
+
+export default () => {
+
+    const router: Router = Router();
+    user(router);
+
+    return router;
+
+}

--- a/backend/src/api/routes/user.ts
+++ b/backend/src/api/routes/user.ts
@@ -1,0 +1,15 @@
+import { Router, Request, Response } from "express";
+import { register, login } from "../../controller/user";
+
+import { validateJWT } from "../../services/user";
+
+const router: Router = Router();
+
+export default (app: Router) => {
+
+    router.post("/register", register);
+    router.post("/login", login);
+
+    app.use("/", router);
+
+};

--- a/backend/src/controller/__tests__/user.test.ts
+++ b/backend/src/controller/__tests__/user.test.ts
@@ -1,0 +1,212 @@
+import { Request, Response } from 'express';
+import { register, login } from '../user';
+import UserModel from '../../models/user';
+import { encryptPassword, comparePassword, generateJWT } from '../../services/user';
+
+jest.mock('../../models/user');
+jest.mock('../../services/user');
+
+const mockResponse = () => {
+  const res = {} as Response;
+  res.status = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  res.sendStatus = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('User Controller', () => {
+  describe('register', () => {
+    it('should register a user successfully', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'password123',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      // Mock dependencies
+      (encryptPassword as jest.Mock).mockResolvedValue('encryptedPassword');
+      (UserModel.prototype.save as jest.Mock).mockResolvedValue({
+        email: 'test@example.com',
+      });
+
+      await register(req, res);
+
+      expect(encryptPassword).toHaveBeenCalledWith('password123');
+      expect(UserModel.prototype.save).toHaveBeenCalled();
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'User with email test@example.com has been successfully saved to our database',
+      });
+    });
+
+    it('should fail when required params are missing', async () => {
+      const req = {
+        body: {},
+      } as Request;
+
+      const res = mockResponse();
+
+      await register(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'request missing key params email,password',
+      });
+    });
+
+    it('should fail when password length is invalid', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'short',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      await register(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'password must contain at least 8 characters and less than 50 characters',
+      });
+    });
+
+    it('should handle errors during registration', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'password123',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      (encryptPassword as jest.Mock).mockRejectedValue(new Error('Encryption failed'));
+
+      await register(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'there was a failure while trying to register, please try again',
+      });
+    });
+  });
+
+  describe('login', () => {
+    it('should log in a user successfully', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'password123',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      // Mock dependencies
+      (UserModel.findOne as jest.Mock).mockResolvedValue({
+        _id: 'user-id',
+        email: 'test@example.com',
+        password: 'encryptedPassword',
+      });
+
+      (comparePassword as jest.Mock).mockResolvedValue(true);
+      (generateJWT as jest.Mock).mockResolvedValue('jwt-token');
+
+      await login(req, res);
+
+      expect(UserModel.findOne).toHaveBeenCalledWith({ email: 'test@example.com' });
+      expect(comparePassword).toHaveBeenCalledWith('password123', 'encryptedPassword');
+      expect(generateJWT).toHaveBeenCalledWith('user-id', 'test@example.com');
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'login successful',
+        email: 'test@example.com',
+        token: 'jwt-token',
+      });
+    });
+
+    it('should fail when required params are missing', async () => {
+      const req = {
+        body: {},
+      } as Request;
+
+      const res = mockResponse();
+
+      await login(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'request missing key params email,password',
+      });
+    });
+
+    it('should fail when user is not found', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'password123',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      (UserModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      await login(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'login unsuccessful due to incorrect email or password',
+      });
+    });
+
+    it('should fail when password does not match', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'wrongpassword',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      (UserModel.findOne as jest.Mock).mockResolvedValue({
+        _id: 'user-id',
+        email: 'test@example.com',
+        password: 'encryptedPassword',
+      });
+
+      (comparePassword as jest.Mock).mockResolvedValue(false);
+
+      await login(req, res);
+
+      expect(res.send).toHaveBeenCalledWith({
+        status: 'failure',
+        message: 'login unsuccessful due to incorrect email or password',
+      });
+    });
+
+    it('should handle errors during login', async () => {
+      const req = {
+        body: {
+          email: 'test@example.com',
+          password: 'password123',
+        },
+      } as Request;
+
+      const res = mockResponse();
+
+      (UserModel.findOne as jest.Mock).mockRejectedValue(new Error('Database error'));
+
+      await login(req, res);
+
+      expect(res.sendStatus).toHaveBeenCalledWith(500);
+    });
+  });
+});

--- a/backend/src/controller/user.ts
+++ b/backend/src/controller/user.ts
@@ -1,0 +1,159 @@
+import UserModel from "../models/user";
+import { Request, Response } from "express";
+import { BaseResponseInterface, LoginResponseInterface } from "../shared/interface/responseInterface"
+import { UserInterface } from "../shared/interface/modelInterface";
+import { 
+    encryptPassword, 
+    comparePassword, 
+    generateJWT
+} from "../services/user";
+
+
+export async function register(req: Request, res: Response) {
+
+    // Declare necessary variables
+    let response: BaseResponseInterface;
+    let requiredParams = ["email", "password"];
+    let containsRequiredParams = requiredParams.every(param => Object.keys(req.body).includes(param));
+
+    if (!containsRequiredParams) {
+
+        // Construct a fail response when missing parameters
+        response = {
+            status: "failure",
+            message: `request missing key params ${requiredParams}`
+        };
+
+        res.status(400).send(response);
+
+    } else {
+
+        try {
+
+            // Check if password meets standard
+            if (req.body.password.length < 8 || req.body.password.length > 50) {
+
+                // Construct a fail response when password didn't meets standard
+                response = {
+                    status: "failure",
+                    message: "password must contain at least 8 characters and less than 50 characters"
+                };
+
+                res.status(400).send(response);
+
+            };
+
+            // Await for password to finish hashing
+            let encrypetedPassword: String = await encryptPassword(req.body.password);
+
+            // Get necessary user data from request
+            let userData = (({ email, password }) => ({ email, password }))(req.body)
+            userData.password = encrypetedPassword;
+
+            // Save the value to the database
+            let userModel: UserInterface = await new UserModel(userData).save();
+
+            // Construct a success response when registration is successful
+            response = {
+                status: "success",
+                message: `User with email ${userModel.email} has been successfully saved to our database`
+            };
+
+            res.status(200).send(response);
+
+        } catch (err:any) {
+
+            if(err?.code === 11000){
+                response = {
+                    status: "failure",
+                    message: "the email provided was already used"
+                };
+
+                res.status(409).send(response);
+                return;
+            }
+
+            // Construct a fail response when something went wrong
+            response = {
+                status: "failure",
+                message: "there was a failure while trying to register, please try again"
+            };
+            console.log(err);
+
+            res.status(500).send(response);
+        };
+
+    };
+
+};
+
+export async function login(req: Request, res: Response) {
+
+    try{
+
+        // Declare necessary variables
+        let response: LoginResponseInterface;
+        let requiredParams = ["email", "password"];
+        let containsRequiredParams = requiredParams.every(param => Object.keys(req.body).includes(param));
+
+        if(!containsRequiredParams){
+
+            // Construct a fail response when missing parameters
+            response = {
+                status: "failure",
+                message: `request missing key params ${requiredParams}`
+            };
+
+            res.status(400).send(response);
+
+        } else {
+
+            let selectedUser: UserInterface | null = await UserModel.findOne({"email": req.body.email});
+            if(selectedUser){
+                // Check if password is correct
+                let doesPasswordMatch: boolean = await comparePassword(req.body.password, selectedUser.password.valueOf());
+                if(doesPasswordMatch){
+
+                    // Create JWT Token
+                    let jwtTokenPromise: Promise<string> = generateJWT(selectedUser._id.toString(), selectedUser.email);
+
+                    let jwtToken: string = await jwtTokenPromise;
+
+                        // Construct a success response when login is successful
+                        response = {
+                            status: "success",
+                            message: "login successful",
+                            email: selectedUser.email,
+                            token: jwtToken
+                        };
+
+                        res.send(response);
+                } else {
+
+                    // Construct a failure response when login has failed
+                    response = {
+                        status: "failure",
+                        message: "login unsuccessful due to incorrect email or password",
+                    };
+
+                    res.send(response);
+
+                };
+            } else{
+                
+                // Construct a failure response when login has failed
+                response = {
+                    status: "failure",
+                    message: "login unsuccessful due to incorrect email or password",
+                };
+
+                res.send(response);
+
+            }
+        };
+    } catch (err) {
+        console.log(err);
+        res.sendStatus(500);
+    };
+
+};

--- a/backend/src/integration_tests/user.test.ts
+++ b/backend/src/integration_tests/user.test.ts
@@ -1,0 +1,137 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+import jwt from 'jsonwebtoken';
+import app from '../server';
+import UserModel from '../models/user';
+import { connectDb } from '../config/db';
+
+describe('Authentication Integration Tests', () => {
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.JWT_SECRET = 'testsecret';
+
+    await connectDb();
+  });
+
+  afterAll(async () => {
+    await mongoose.connection.close();
+  });
+
+  afterEach(async () => {
+    // Clear the database after each test
+    await UserModel.deleteMany({});
+  });
+
+  it('should register a new user', async () => {
+    const response = await request(app).post('/register').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('success');
+    expect(response.body.message).toContain('User with email test@example.com has been successfully saved');
+
+    // Verify user is in the database
+    const user = await UserModel.findOne({ email: 'test@example.com' });
+    expect(user).not.toBeNull();
+    expect(user!.email).toBe('test@example.com');
+  });
+
+  it('should fail when there is duplicate emails', async () => {
+    let response = await request(app).post('/register').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('success');
+    expect(response.body.message).toContain('User with email test@example.com has been successfully saved');
+
+    response = await request(app).post('/register').send({
+        email: 'test@example.com',
+        password: 'password123',
+    });
+
+    const user = await UserModel.find({ email: 'test@example.com' })
+    expect(response.status).toBe(409);
+    expect(response.body.status).toBe('failure');
+    expect(response.body.message).toContain('the email provided was already used');
+    expect(user.length).toBe(1);
+
+  });
+
+  it('should not register a user with missing password', async () => {
+    const response = await request(app).post('/register').send({
+      email: 'test2@example.com',
+      // password is missing
+    });
+
+    expect(response.status).toBe(400); // Adjust if your API returns different status codes
+    expect(response.body.status).toBe('failure');
+    expect(response.body.message).toContain('request missing key params');
+
+    // Verify user is not in the database
+    const user = await UserModel.findOne({ email: 'test2@example.com' });
+    expect(user).toBeNull();
+  });
+
+  it('should login an existing user', async () => {
+    // Register a user first
+    await request(app).post('/register').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+
+    const response = await request(app).post('/login').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('success');
+    expect(response.body.message).toBe('login successful');
+    expect(response.body.email).toBe('test@example.com');
+    expect(response.body.token).toBeDefined();
+
+    const token = response.body.token;
+    const JWT_SECRET = process.env.JWT_SECRET!;
+    const decoded = jwt.verify(token, JWT_SECRET) as jwt.JwtPayload;
+
+    expect(decoded).toBeDefined();
+    console.log(decoded)
+    expect(decoded.id).toBeDefined();
+    expect(decoded.email).toBe('test@example.com');
+
+    // Optionally, verify token expiration, etc.
+    expect(decoded.exp).toBeGreaterThan(decoded.iat!);
+  });
+
+  it('should not login with incorrect password', async () => {
+    // Register a user first
+    await request(app).post('/register').send({
+      email: 'test@example.com',
+      password: 'password123',
+    });
+
+    const response = await request(app).post('/login').send({
+      email: 'test@example.com',
+      password: 'wrongpassword',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('failure');
+    expect(response.body.message).toContain('login unsuccessful due to incorrect email or password');
+  });
+
+  it('should not login non-existent user', async () => {
+    const response = await request(app).post('/login').send({
+      email: 'nonexistent@example.com',
+      password: 'password123',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('failure');
+    expect(response.body.message).toContain('login unsuccessful due to incorrect email or password');
+  });
+});

--- a/backend/src/models/__tests__/user.test.ts
+++ b/backend/src/models/__tests__/user.test.ts
@@ -1,0 +1,101 @@
+// src/tests/userModel.test.ts
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import UserModel from '../user';
+import { UserInterface } from '../../shared/interface/modelInterface';
+
+describe('User Model Test', () => {
+  let mongoServer: MongoMemoryServer;
+
+  beforeAll(async () => {
+    // Start MongoMemoryServer
+    mongoServer = await MongoMemoryServer.create();
+    const uri = mongoServer.getUri();
+
+    // Connect mongoose to the in-memory database
+    await mongoose.connect(uri);
+  });
+
+  afterAll(async () => {
+    // Disconnect mongoose and stop the server
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  afterEach(async () => {
+    // Clear all collections after each test
+    const collections = mongoose.connection.collections;
+    for (const key in collections) {
+      await collections[key].deleteMany({});
+    }
+  });
+
+  it('should create & save a user successfully', async () => {
+    const userData: Partial<UserInterface> = {
+      email: 'test@example.com',
+      password: 'Password123!',
+      is_superuser: true,
+    };
+
+    const validUser = new UserModel(userData);
+    const savedUser = await validUser.save();
+
+    // Assertions
+    expect(savedUser._id).toBeDefined();
+    expect(savedUser.email).toBe(userData.email);
+    expect(savedUser.password).toBe(userData.password);
+    expect(savedUser.is_superuser).toBe(true);
+  });
+
+  it('should default is_superuser to false if not provided', async () => {
+    const userData: Partial<UserInterface> = {
+      email: 'user2@example.com',
+      password: 'Password123!',
+    };
+
+    const userWithoutSuperuser = new UserModel(userData);
+    const savedUser = await userWithoutSuperuser.save();
+
+    // Assertions
+    expect(savedUser._id).toBeDefined();
+    expect(savedUser.is_superuser).toBe(false);
+  });
+
+  it('should fail to create a user without required fields', async () => {
+    const userData: Partial<UserInterface> = {
+      email: 'user3@example.com',
+    };
+
+    const userWithoutPassword = new UserModel(userData);
+    let err: mongoose.Error.ValidationError | undefined = undefined;
+
+    try {
+      await userWithoutPassword.save();
+    } catch (error) {
+      err = error as mongoose.Error.ValidationError;
+    }
+
+    // Assertions
+    expect(err).toBeDefined();
+    expect(err?.errors).toHaveProperty('password');
+  });
+
+  it('should fail when email is not provided', async () => {
+    const userData: Partial<UserInterface> = {
+      password: 'Password123!',
+    };
+
+    const userWithoutEmail = new UserModel(userData);
+    let err: mongoose.Error.ValidationError | undefined = undefined;
+
+    try {
+      await userWithoutEmail.save();
+    } catch (error) {
+      err = error as mongoose.Error.ValidationError;
+    }
+
+    // Assertions
+    expect(err).toBeDefined();
+    expect(err?.errors).toHaveProperty('email');
+  });
+});

--- a/backend/src/models/user.ts
+++ b/backend/src/models/user.ts
@@ -1,0 +1,21 @@
+import { Schema, Types, model } from "mongoose";
+import { UserInterface } from "../shared/interface/modelInterface";
+
+const UserSchema: Schema<UserInterface> = new Schema({
+    "email" : {
+        type: String,
+        required: true,
+        unique: true
+    },
+    "password": {
+        type: String,
+        required: true
+    },
+    "is_superuser": {
+        type: Boolean,
+        default: false,
+        required: true
+    }
+}, {versionKey: false});
+
+export default model<UserInterface>("User", UserSchema);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,8 +9,6 @@ import router from "./api/router";
 // Inject env variable
 dotenv.config({path: path.join(__dirname, "../.env")});
 
-connectDb();
-
 const app: Application = express();
 const PORT: Number = Number(process.env.port) || 3102;
 
@@ -21,4 +19,10 @@ app.use(cors());
 app.use(mongoSanitize());
 app.use("/", router());
 
-app.listen(PORT, () => console.log(`Server started at Port: ${PORT}`));
+// Start the server only if not in test environment
+if (process.env.NODE_ENV !== 'test') {
+    connectDb();
+    app.listen(PORT, () => console.log(`Server started at Port: ${PORT}`));
+}
+
+export default app;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import path from "path";
 import cors from "cors"
 import mongoSanitize from "express-mongo-sanitize";
 import { connectDb } from "./config/db"
+import router from "./api/router";
 
 // Inject env variable
 dotenv.config({path: path.join(__dirname, "../.env")});
@@ -18,5 +19,6 @@ app.use(express.json());
 app.use(express.urlencoded());
 app.use(cors());
 app.use(mongoSanitize());
+app.use("/", router());
 
 app.listen(PORT, () => console.log(`Server started at Port: ${PORT}`));

--- a/backend/src/services/__tests__/user.test.ts
+++ b/backend/src/services/__tests__/user.test.ts
@@ -1,0 +1,119 @@
+import { encryptPassword, comparePassword, generateJWT, validateJWT } from '../user';
+import { JwtPayloadInterface } from '../../shared/interface/authInterface';
+import jwt from 'jsonwebtoken';
+
+describe('User Service Tests', () => {
+  describe('encryptPassword', () => {
+    it('should return a hashed password different from the original password', async () => {
+      const password = 'MySecretPassword123!';
+      const hashedPassword = await encryptPassword(password);
+
+      expect(hashedPassword).not.toEqual(password);
+      expect(typeof hashedPassword).toBe('string');
+      expect(hashedPassword.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('comparePassword', () => {
+    it('should return true when the password matches the hash', async () => {
+      const password = 'MySecretPassword123!';
+      const hashedPassword = await encryptPassword(password);
+
+      const isMatch = await comparePassword(password, hashedPassword);
+      expect(isMatch).toBe(true);
+    });
+
+    it('should return false when the password does not match the hash', async () => {
+      const password = 'MySecretPassword123!';
+      const wrongPassword = 'WrongPassword!';
+      const hashedPassword = await encryptPassword(password);
+
+      const isMatch = await comparePassword(wrongPassword, hashedPassword);
+      expect(isMatch).toBe(false);
+    });
+  });
+
+  describe('generateJWT', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return a JWT token when JWT_SECRET is set', async () => {
+      process.env.JWT_SECRET = 'testsecret';
+
+      const id = '12345';
+      const email = 'test@test.com';
+
+      const token = await generateJWT(id, email);
+
+      expect(typeof token).toBe('string');
+      expect(token.length).toBeGreaterThan(0);
+
+      // Verify the token
+      const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayloadInterface;
+      expect(decoded.id).toBe(id);
+      expect(decoded.email).toBe(email);
+    });
+
+    it('should throw an error when JWT_SECRET is not set', async () => {
+      delete process.env.JWT_SECRET;
+
+      const id = '12345';
+      const username = 'testuser';
+
+      await expect(generateJWT(id, username)).rejects.toEqual('JWT Secret not found');
+    });
+  });
+
+  describe('validateJWT', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return the decrypted payload when given a valid token', async () => {
+      process.env.JWT_SECRET = 'testsecret';
+
+      const id = '12345';
+      const email = 'test@test.com';
+
+      const token = await generateJWT(id, email);
+      const payload = await validateJWT(token);
+
+      expect(payload).toBeDefined();
+      expect(payload!.id).toBe(id);
+      expect(payload!.email).toBe(email);
+    });
+
+    it('should return undefined when given an invalid token', async () => {
+      process.env.JWT_SECRET = 'testsecret';
+
+      const invalidToken = 'this.is.not.a.valid.token';
+
+      const payload = await validateJWT(invalidToken);
+
+      expect(payload).toBeUndefined();
+    });
+
+    it('should throw an error when JWT_SECRET is not set', async () => {
+      delete process.env.JWT_SECRET;
+
+      const token = 'someToken';
+
+      await expect(validateJWT(token)).rejects.toEqual('JWT Secret not found');
+    });
+  });
+});

--- a/backend/src/services/user.ts
+++ b/backend/src/services/user.ts
@@ -1,0 +1,51 @@
+import bcrypt from "bcrypt";
+import jwt from "jsonwebtoken";
+import crypto from "crypto";
+import { JwtPayloadInterface } from "../shared/interface/authInterface";
+
+export function encryptPassword(password: string) { 
+
+    const saltRound: number = 10;
+    return bcrypt.hash(password, saltRound);
+
+};
+
+export async function comparePassword(password: string, hash: string) {
+
+    return bcrypt.compare(password, hash);
+
+};
+
+export async function generateJWT(id: String, email: String){
+
+    const JWT_SECRET: string | undefined = process.env.JWT_SECRET;
+
+    let userObject = {id, email};
+    
+    if (JWT_SECRET) {
+        return jwt.sign(userObject, JWT_SECRET, {expiresIn: "3d"});
+    } else {
+        throw "JWT Secret not found";
+    };
+    
+}
+
+export async function validateJWT(token: String){
+
+    const JWT_SECRET: string | undefined = process.env.JWT_SECRET;
+
+    if (JWT_SECRET) {
+
+        try{
+            let decrypted: JwtPayloadInterface = <any>jwt.verify(token.toString(), JWT_SECRET);
+            return decrypted;
+        }catch(error){
+            return;
+        }
+        
+
+    }else {
+        throw "JWT Secret not found";
+    }
+
+}

--- a/backend/src/shared/interface/authInterface.ts
+++ b/backend/src/shared/interface/authInterface.ts
@@ -1,0 +1,6 @@
+export interface JwtPayloadInterface {
+    id: String,
+    email: String,
+    iat: number,
+    exp: number
+}

--- a/backend/src/shared/interface/modelInterface.ts
+++ b/backend/src/shared/interface/modelInterface.ts
@@ -1,0 +1,16 @@
+import { Document, ObjectId, Types } from "mongoose"
+
+export interface UserInterface extends Document {
+    email: String
+    password: String,
+    is_superuser: Boolean
+}
+
+export interface AuthInterface extends Document {
+    user_id: Types.ObjectId,
+    auth1: String,
+    auth2: String,
+    created: Date,
+    expired: Date
+}
+

--- a/backend/src/shared/interface/responseInterface.ts
+++ b/backend/src/shared/interface/responseInterface.ts
@@ -1,0 +1,9 @@
+export interface BaseResponseInterface {
+    status: String;
+    message: String;
+}
+
+export interface LoginResponseInterface extends BaseResponseInterface {
+    email?: String;
+    token?: String;
+}


### PR DESCRIPTION
This PR added login and register API endpoints to the backend. For login, it accepts 'email' and 'password' and return the JwtToken as response. This can be used to authenticate the user. Register accepts the same parameters.