### PR TITLE
45 un/register event

### DIFF
--- a/backend/src/controller/events.ts
+++ b/backend/src/controller/events.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
-import { BaseResponseInterface, GetEventResponseInterface } from "../shared/interface/responseInterface";
-import { getEvents } from "../services/events";
+import { BaseResponseInterface, GetEventResponseInterface, RegisterEventResponseInterface } from "../shared/interface/responseInterface";
+import { getEvents, registerOrUnregisterEvent } from "../services/events";
 import { register } from "./user";
 
 // Get list of all events
@@ -99,6 +99,60 @@ export async function getRegisteredEvents(req: Request, res: Response) {
 
 // Register/unregister for an event
 export async function registerForEvent(req: Request, res: Response) {
-    // Logic for registering/unregistering for an event
-    res.status(200).json({ message: 'Registration status updated' });
+    // Declare necessary variables
+    let response: BaseResponseInterface;
+    let requiredParams = ["eventId"];
+    let containsRequiredParams = requiredParams.every(param => Object.keys(req.body).includes(param));
+
+    if (!containsRequiredParams) {
+        // Construct a failure response when missing parameters
+        response = {
+            status: "failure",
+            message: `Request is missing key parameters: ${requiredParams.join(", ")}`
+        };
+        res.status(400).send(response);
+    } else {
+        try {
+            const userId = req.body.authPayload.id;
+            const eventId = req.body.eventId;
+
+            // Call service function to register or unregister the event
+            const unregistered = await registerOrUnregisterEvent(userId, eventId);
+
+            // Construct a success response
+            const successResponse: RegisterEventResponseInterface = {
+                status: "success",
+                message: unregistered
+                    ? "Successfully unregistered from the event."
+                    : "Successfully registered for the event.",
+                unregistered: unregistered
+            };
+            res.status(200).send(successResponse);
+        } catch (err: any) {
+            // Handle specific errors if necessary
+            if (err.message === 'EventNotFound') {
+                response = {
+                    status: "failure",
+                    message: "Event not found."
+                };
+                res.status(404).send(response);
+                return;
+            } else if (err.message === 'ProfileNotFound') {
+                response = {
+                    status: "failure",
+                    message: "User profile not found."
+                };
+                res.status(404).send(response);
+                return;
+            }
+
+            // Construct a failure response for general errors
+            response = {
+                status: "failure",
+                message: "An error occurred while processing the request."
+            };
+            console.error(err);
+            res.status(500).send(response);
+        }
+    }
 }

--- a/backend/src/integration_tests/events.test.ts
+++ b/backend/src/integration_tests/events.test.ts
@@ -1,8 +1,9 @@
 import request from 'supertest';
 import mongoose from 'mongoose';
 import app from '../server';
-import EventModel from '../models/events'
+import EventModel from '../models/events';
 import UserModel from '../models/user';
+import ProfileModel from '../models/profile';
 import { generateJWT } from '../services/user';
 import { connectDb } from '../config/db';
 
@@ -10,6 +11,7 @@ describe('Events Integration Test', () => {
     let defaultUser: any;
     let userObject: any;
     let token: string;
+    let eventIds: string[] = [];
 
     beforeAll(async () => {
         await connectDb();
@@ -27,6 +29,21 @@ describe('Events Integration Test', () => {
         const userId = user._id.toString();
         const email = user.email;
         token = await generateJWT(userId, email);
+
+        await new ProfileModel({
+            userId: userId,
+            username: 'testuser',
+            dateOfBirth: '1990-01-01',
+            year: 'Senior',
+            major: 'Computer Science',
+            college: 'Engineering',
+            classes: 'CS101, CS102',
+            hobby: 'Reading',
+            musicPreference: 'Rock',
+            favArtists: 'Artist1, Artist2',
+            contact: 'testuser@example.com',
+            description: 'This is a test user.',
+        }).save();
 
         const events = [
             {
@@ -58,105 +75,228 @@ describe('Events Integration Test', () => {
             }
         ];
 
-        await EventModel.insertMany(events);
+        const insertedEvents = await EventModel.insertMany(events);
+        eventIds = insertedEvents.map(event => event._id.toString());
     });
 
     afterAll(async () => {
         await UserModel.deleteMany({});
+        await ProfileModel.deleteMany({});
         await mongoose.connection.close();
     });
 
     afterEach(async () => {
         await UserModel.deleteMany({});
+        await ProfileModel.deleteMany({});
 
         const user = new UserModel(defaultUser);
         userObject = await user.save();
         const userId = userObject._id.toString();
         const email = user.email;
         token = await generateJWT(userId, email);
+
+        await new ProfileModel({
+            userId: userId,
+            username: 'testuser',
+            dateOfBirth: '1990-01-01',
+            year: 'Senior',
+            major: 'Computer Science',
+            college: 'Engineering',
+            classes: 'CS101, CS102',
+            hobby: 'Reading',
+            musicPreference: 'Rock',
+            favArtists: 'Artist1, Artist2',
+            contact: 'testuser@example.com',
+            description: 'This is a test user.',
+        }).save();
     });
 
-    it('should return all events sorted by date ascending when no parameters are provided', async () => {
+    describe("get all event tests", () => {
+        it('should return all events sorted by date ascending when no parameters are provided', async () => {
 
-        const response = await request(app)
-            .get('/events')
-            .set('Authorization', `Bearer ${token}`)
-            .expect(200);
+            const response = await request(app)
+                .get('/events')
+                .set('Authorization', `Bearer ${token}`)
+                .expect(200);
 
-        // Assert
-        expect(response.body.status).toBe('success');
-        expect(response.body.events).toHaveLength(3);
+            // Assert
+            expect(response.body.status).toBe('success');
+            expect(response.body.events).toHaveLength(3);
 
-        const returnedEventNames = response.body.events.map((event: any) => event.eventName);
-        expect(returnedEventNames).toEqual(['Event 1', 'Event 3', 'Event 2']);
+            const returnedEventNames = response.body.events.map((event: any) => event.eventName);
+            expect(returnedEventNames).toEqual(['Event 1', 'Event 3', 'Event 2']);
 
-        expect(response.body.events[0].attendee).toEqual(3);
-        expect(response.body.events[0].registered).toBe(true);
-        expect(response.body.events[1].attendee).toEqual(0);
-        expect(response.body.events[1].registered).toBe(false);
-        expect(response.body.events[2].attendee).toEqual(0);
-        expect(response.body.events[2].registered).toBe(false);
+            expect(response.body.events[0].attendee).toEqual(3);
+            expect(response.body.events[0].registered).toBe(true);
+            expect(response.body.events[1].attendee).toEqual(0);
+            expect(response.body.events[1].registered).toBe(false);
+            expect(response.body.events[2].attendee).toEqual(0);
+            expect(response.body.events[2].registered).toBe(false);
+        });
+
+        it('should return events sorted by date descending when sort=dsc is provided', async () => {
+            const response = await request(app)
+                .get('/events?sort=dsc')
+                .set('Authorization', `Bearer ${token}`)
+                .expect(200);
+
+            // Assert
+            expect(response.body.status).toBe('success');
+            expect(response.body.events).toHaveLength(3);
+
+            const returnedEventNames = response.body.events.map((event: any) => event.eventName);
+            expect(returnedEventNames).toEqual(['Event 2', 'Event 3', 'Event 1']);
+        });
+
+        it('should return limited number of events when max parameter is provided', async () => {
+
+            // Act
+            const response = await request(app)
+                .get('/events?max=2')
+                .set('Authorization', `Bearer ${token}`)
+                .expect(200);
+
+            // Assert
+            expect(response.body.status).toBe('success');
+            expect(response.body.events).toHaveLength(2);
+
+            const returnedEventNames = response.body.events.map((event: any) => event.eventName);
+            expect(returnedEventNames).toEqual(['Event 1', 'Event 3']);
+        });
+
+        it('should return error when invalid sort parameter is provided', async () => {
+            // Act
+            const response = await request(app)
+                .get('/events?sort=invalid')
+                .set('Authorization', `Bearer ${token}`)
+                .expect(400);
+
+            // Assert
+            expect(response.body.status).toBe('failure');
+            expect(response.body.message).toBe("Invalid sort parameter. Allowed values are 'asc' or 'dsc'.");
+        });
+
+        it('should return error when invalid max parameter is provided', async () => {
+            // Act
+            const response = await request(app)
+                .get('/events?max=-1')
+                .set('Authorization', `Bearer ${token}`)
+                .expect(400);
+
+            // Assert
+            expect(response.body.status).toBe('failure');
+            expect(response.body.message).toBe("Invalid max parameter. It must be a positive integer.");
+        });
+
+        it('should return unauthorized when no token is provided', async () => {
+            // Act
+            const response = await request(app)
+                .get('/events')
+                .expect(403);
+        });
     });
 
-    it('should return events sorted by date descending when sort=dsc is provided', async () => {
-        const response = await request(app)
-            .get('/events?sort=dsc')
-            .set('Authorization', `Bearer ${token}`)
-            .expect(200);
+    describe("register for event tests", () => {
+        it('should successfully register for an event when not already registered', async () => {
+            // Arrange
+            const userId = userObject._id.toString();
+            const eventIdToRegister = eventIds[1]; // Event 2, user is not registered
 
-        // Assert
-        expect(response.body.status).toBe('success');
-        expect(response.body.events).toHaveLength(3);
+            // Act
+            const response = await request(app)
+                .post('/events/register')
+                .set('Authorization', `Bearer ${token}`)
+                .send({ eventId: eventIdToRegister })
+                .expect(200);
 
-        const returnedEventNames = response.body.events.map((event: any) => event.eventName);
-        expect(returnedEventNames).toEqual(['Event 2', 'Event 3', 'Event 1']);
-    });
+            console.log(response.body);
 
-    it('should return limited number of events when max parameter is provided', async () => {
+            // Assert
+            expect(response.body.status).toBe('success');
+            expect(response.body.message).toBe('Successfully registered for the event.');
+            expect(response.body.unregistered).toBe(false);
 
-        // Act
-        const response = await request(app)
-            .get('/events?max=2')
-            .set('Authorization', `Bearer ${token}`)
-            .expect(200);
+            // Verify user's profile
+            const updatedProfile = await ProfileModel.findOne({ userId });
+            expect(updatedProfile!.event_registered).toContain(eventIdToRegister);
 
-        // Assert
-        expect(response.body.status).toBe('success');
-        expect(response.body.events).toHaveLength(2);
+            // Verify event's userRegistered
+            const updatedEvent = await EventModel.findById(eventIdToRegister);
+            expect(updatedEvent!.userRegistered).toContain(userId);
+        });
 
-        const returnedEventNames = response.body.events.map((event: any) => event.eventName);
-        expect(returnedEventNames).toEqual(['Event 1', 'Event 3']);
-    });
+        it('should successfully unregister from an event when already registered', async () => {
+            // Arrange
+            const userId = userObject._id.toString();
+            const eventIdToRegister = eventIds[1]; // Event 2
 
-    it('should return error when invalid sort parameter is provided', async () => {
-        // Act
-        const response = await request(app)
-            .get('/events?sort=invalid')
-            .set('Authorization', `Bearer ${token}`)
-            .expect(400);
+            // First, register the user for the event
+            await request(app)
+                .post('/events/register')
+                .set('Authorization', `Bearer ${token}`)
+                .send({ eventId: eventIdToRegister })
+                .expect(200);
 
-        // Assert
-        expect(response.body.status).toBe('failure');
-        expect(response.body.message).toBe("Invalid sort parameter. Allowed values are 'asc' or 'dsc'.");
-    });
+            // Act
+            const response = await request(app)
+                .post('/events/register')
+                .set('Authorization', `Bearer ${token}`)
+                .send({ eventId: eventIdToRegister })
+                .expect(200);
 
-    it('should return error when invalid max parameter is provided', async () => {
-        // Act
-        const response = await request(app)
-            .get('/events?max=-1')
-            .set('Authorization', `Bearer ${token}`)
-            .expect(400);
+            // Assert
+            expect(response.body.status).toBe('success');
+            expect(response.body.message).toBe('Successfully unregistered from the event.');
+            expect(response.body.unregistered).toBe(true);
 
-        // Assert
-        expect(response.body.status).toBe('failure');
-        expect(response.body.message).toBe("Invalid max parameter. It must be a positive integer.");
-    });
+            // Verify user's profile
+            const updatedProfile = await ProfileModel.findOne({ userId });
+            expect(updatedProfile!.event_registered).not.toContain(eventIdToRegister);
 
-    it('should return unauthorized when no token is provided', async () => {
-        // Act
-        const response = await request(app)
-            .get('/events')
-            .expect(403);
+            // Verify event's userRegistered
+            const updatedEvent = await EventModel.findById(eventIdToRegister);
+            expect(updatedEvent!.userRegistered).not.toContain(userId);
+        });
+
+        it('should return 404 when trying to register for a non-existent event', async () => {
+            // Arrange
+            const nonExistentEventId = mongoose.Types.ObjectId().toString();
+
+            // Act
+            const response = await request(app)
+                .post('/events/register')
+                .set('Authorization', `Bearer ${token}`)
+                .send({ eventId: nonExistentEventId })
+                .expect(404);
+
+            // Assert
+            expect(response.body.status).toBe('failure');
+            expect(response.body.message).toBe('Event not found.');
+        });
+
+        it('should return 400 when missing eventId in request body', async () => {
+            // Act
+            const response = await request(app)
+                .post('/events/register')
+                .set('Authorization', `Bearer ${token}`)
+                .send({})
+                .expect(400);
+
+            // Assert
+            expect(response.body.status).toBe('failure');
+            expect(response.body.message).toContain('Request is missing key parameters');
+        });
+
+        it('should return unauthorized when no token is provided', async () => {
+            // Arrange
+            const eventIdToRegister = eventIds[1]; // Event 2
+
+            // Act
+            const response = await request(app)
+                .post('/events/register')
+                .send({ eventId: eventIdToRegister })
+                .expect(403);
+        });
     });
 
 });

--- a/backend/src/services/events.ts
+++ b/backend/src/services/events.ts
@@ -1,4 +1,5 @@
 import EventModel from '../models/events';
+import ProfileModel from '../models/profile';
 
 export async function getEvents(sort: string, max?: number) {
     // Determine the sort order
@@ -15,4 +16,37 @@ export async function getEvents(sort: string, max?: number) {
     // Execute the query and return the events
     const events = await query.exec();
     return events;
+}
+
+export async function registerOrUnregisterEvent(userId: string, eventId: string): Promise<boolean> {
+    // Returns true if unregistered, false if registered
+    // Fetch the user's profile
+    const userProfile = await ProfileModel.findOne({ userId: userId });
+    if (!userProfile) {
+        throw new Error('ProfileNotFound');
+    }
+
+    // Fetch the event
+    const event = await EventModel.findById(eventId);
+    if (!event) {
+        throw new Error('EventNotFound');
+    }
+
+    const isRegistered = userProfile.event_registered.includes(eventId);
+
+    if (!isRegistered) {
+        // User is not registered, so register them
+        userProfile.event_registered.push(eventId);
+        event.userRegistered.push(userId);
+        await userProfile.save();
+        await event.save();
+        return false; // Successfully registered
+    } else {
+        // User is already registered, so unregister them
+        userProfile.event_registered = userProfile.event_registered.filter(id => id !== eventId);
+        event.userRegistered = event.userRegistered.filter(id => id !== userId);
+        await userProfile.save();
+        await event.save();
+        return true; // Successfully unregistered
+    }
 }

--- a/backend/src/shared/interface/responseInterface.ts
+++ b/backend/src/shared/interface/responseInterface.ts
@@ -21,3 +21,7 @@ export interface GetEventResponseInterface extends BaseResponseInterface{
         registered: boolean;
     }[];
 }
+
+export interface RegisterEventResponseInterface extends BaseResponseInterface{
+    unregistered: boolean; // true if successfully unregistered, false if successfully registed after calling this endpoint
+}


### PR DESCRIPTION
# SHOULD BE MERGED AFTER #51 

## **Summary**

This pull request introduces a new endpoint that allows users to register or unregister for events. The `POST /events/register` endpoint checks if the user is already registered for the specified event and toggles their registration status accordingly.

## **How to Use**

### **Endpoint**

```
POST /events/register
```

### **Request Headers**

- **Authorization**: Bearer token obtained after user authentication.

### **Request Body**

```json
{
    "eventId": "673c1655c14026ada9bcb671"
}
```

- **eventId** (string, required): The unique identifier of the event to register or unregister for.

### **Response**

- **Successful Registration**

  ```json
  {
      "status": "success",
      "message": "Successfully registered for the event.",
      "unregistered": false
  }
  ```

- **Successful Unregistration**

  ```json
  {
      "status": "success",
      "message": "Successfully unregistered from the event.",
      "unregistered": true
  }
  ```

### **Behavior**

- **Registering for an Event**
  - If the user is not already registered for the event, they will be registered.
  - The `unregistered` field in the response will be `false`.

- **Unregistering from an Event**
  - If the user is already registered for the event, they will be unregistered.
  - The `unregistered` field in the response will be `true`.

## **Example Usage**

### **Register for an Event**

**Request**

```http
POST /events/register
Content-Type: application/json
Authorization: Bearer {token}

{
    "eventId": "673c1655c14026ada9bcb671"
}
```

**Response**

```json
{
    "status": "success",
    "message": "Successfully registered for the event.",
    "unregistered": false
}
```

### **Unregister from an Event**

**Request**

```http
POST /events/register
Content-Type: application/json
Authorization: Bearer {token}

{
    "eventId": "673c1655c14026ada9bcb671"
}
```

**Response**

```json
{
    "status": "success",
    "message": "Successfully unregistered from the event.",
    "unregistered": true
}
```

## **Important Notes**

- **Authentication Required**: This endpoint requires the user to be authenticated. Ensure that the `Authorization` header is set with a valid JWT token.

- **Event ID Validation**: The `eventId` must be a valid identifier of an existing event. If the event does not exist, the endpoint will return a `404 Not Found` error.

- **Idempotent Behavior**: Calling the endpoint repeatedly will toggle the user's registration status for the specified event.