### PR TITLE
Add friend request respond endpoint

### DIFF
--- a/backend/src/api/routes/people.ts
+++ b/backend/src/api/routes/people.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
-import { getRecommendations, matchPeople, getMatches, viewProfile } from "../../controller/people";
+import { getRecommendations, matchPeople, getMatches, viewProfile, respondToMatchRequest } from "../../controller/people";
 import { requireAuthorization } from "../../middlewares/user";
+
 const router: Router = Router();
 export default (app: Router) => {
     router.get("/recommendations", requireAuthorization, getRecommendations); // Get recommendations for people
+    router.post("/match/response", requireAuthorization, respondToMatchRequest);
     router.post("/match", requireAuthorization, matchPeople);                 // Send a match request
     router.get("/match", requireAuthorization, getMatches);                   // Get list of matches
     router.get("/view/:id", requireAuthorization, viewProfile);               // View matched profile

--- a/backend/src/services/people.ts
+++ b/backend/src/services/people.ts
@@ -1,37 +1,111 @@
 import ProfileModel from '../models/profile';
 import NotificationModel from '../models/notifications';
-import { NOTIFICATION_MATCH_REQUEST, NotificationInterface } from '../shared/interface/modelInterface';
+import { NOTIFICATION_MATCH_DENIED, NOTIFICATION_MATCH_REQUEST, NOTIFICATION_MATCHED, NotificationInterface } from '../shared/interface/modelInterface';
 
 export async function sendFriendRequest(userId: string, targetUserId: string) {
-  // Fetch the requester's profile
-  const requesterProfile = await ProfileModel.findOne({ userId: userId });
-  if (!requesterProfile) {
-    throw new Error('ProfileNotFound');
-  }
+    // Fetch the requester's profile
+    const requesterProfile = await ProfileModel.findOne({ userId: userId });
+    if (!requesterProfile) {
+        throw new Error('ProfileNotFound');
+    }
 
-  // Fetch the target user's profile
-  const targetProfile = await ProfileModel.findOne({ userId: targetUserId });
-  if (!targetProfile) {
-    throw new Error('TargetProfileNotFound');
-  }
+    // Fetch the target user's profile
+    const targetProfile = await ProfileModel.findOne({ userId: targetUserId });
+    if (!targetProfile) {
+        throw new Error('TargetProfileNotFound');
+    }
 
-  // Check if the friend request was already made
-  if (requesterProfile.friend_requested.includes(targetUserId)) {
-    throw new Error('FriendRequestAlreadyMade');
-  }
+    // Check if the friend request was already made
+    if (requesterProfile.friend_requested.includes(targetUserId)) {
+        throw new Error('FriendRequestAlreadyMade');
+    }
 
-  // Add targetUserId to friend_requested array in requester's profile
-  requesterProfile.friend_requested.push(targetUserId);
-  await requesterProfile.save();
+    // Add targetUserId to friend_requested array in requester's profile
+    requesterProfile.friend_requested.push(targetUserId);
+    await requesterProfile.save();
 
-  // Create a notification for the recipient
-  const notification: Partial<NotificationInterface> = {
-    userId: targetUserId,  // The recipient of the notification
-    type: NOTIFICATION_MATCH_REQUEST, // Assuming type 1 corresponds to friend request notifications
-    targetId: userId, // The ID of the user who sent the friend request
-    date: new Date()
-  };
+    // Create a notification for the recipient
+    const notification: Partial<NotificationInterface> = {
+        userId: targetUserId,  // The recipient of the notification
+        type: NOTIFICATION_MATCH_REQUEST, // Assuming type 1 corresponds to friend request notifications
+        targetId: userId, // The ID of the user who sent the friend request
+        date: new Date()
+    };
 
-  const newNotification = new NotificationModel(notification);
-  await newNotification.save();
+    const newNotification = new NotificationModel(notification);
+    await newNotification.save();
+}
+
+export async function respondToFriendRequest(recipientUserId: string, requesterUserId: string, accept: boolean) {
+    // Fetch the recipient's profile
+    const recipientProfile = await ProfileModel.findOne({ userId: recipientUserId });
+    if (!recipientProfile) {
+        throw new Error('ProfileNotFound');
+    }
+
+    // Fetch the requester's profile
+    const requesterProfile = await ProfileModel.findOne({ userId: requesterUserId });
+    if (!requesterProfile) {
+        throw new Error('RequesterProfileNotFound');
+    }
+
+    // Check if the requesterUserId is in the recipient's friend_requested list
+    if (!requesterProfile.friend_requested.includes(recipientUserId)) {
+        throw new Error('FriendRequestNotFound');
+    }
+
+    // Remove requesterUserId from recipient's friend_requested list
+    requesterProfile.friend_requested = requesterProfile.friend_requested.filter(id => id !== recipientUserId);
+
+    if (accept) {
+        // Add each other to friend lists
+        recipientProfile.friend.push(requesterUserId);
+        requesterProfile.friend.push(recipientUserId);
+
+        // Create matched notifications
+        const recipientNotification: Partial<NotificationInterface> = {
+            userId: recipientUserId,
+            type: NOTIFICATION_MATCHED,
+            targetId: requesterUserId,
+            date: new Date()
+        };
+
+        const requesterNotification: Partial<NotificationInterface> = {
+            userId: requesterUserId,
+            type: NOTIFICATION_MATCHED,
+            targetId: recipientUserId,
+            date: new Date()
+        };
+
+        // Remove friend request notification from recipient
+        await NotificationModel.deleteOne({
+            userId: recipientUserId,
+            type: NOTIFICATION_MATCH_REQUEST,
+            targetId: requesterUserId
+        });
+
+        // Save notifications
+        await NotificationModel.insertMany([recipientNotification, requesterNotification]);
+    } else {
+
+        const rejectionNotification = new NotificationModel({
+            userId: requesterUserId,
+            type: NOTIFICATION_MATCH_DENIED,
+            targetId: recipientUserId,
+            date: new Date()
+        });
+
+        await rejectionNotification.save();
+
+        // If rejected, remove friend request notification from recipient
+        await NotificationModel.deleteOne({
+            userId: recipientUserId,
+            type: NOTIFICATION_MATCH_REQUEST,
+            targetId: requesterUserId
+        });
+    }
+
+    // Save profiles
+    await recipientProfile.save();
+    await requesterProfile.save();
 }

--- a/backend/src/shared/interface/modelInterface.ts
+++ b/backend/src/shared/interface/modelInterface.ts
@@ -44,7 +44,7 @@ export interface EventInterface extends Document {
 
 export const NOTIFICATION_MATCH_REQUEST = 0;
 export const NOTIFICATION_MATCHED = 1;
-
+export const NOTIFICATION_MATCH_DENIED = 2;
 
 export interface NotificationInterface extends Document {
   userId: string; // userId of the user that this notification belongs to


### PR DESCRIPTION
# MUST MERGE AFTER 59
# Pull Request: Add Friend Request Response Endpoint (`POST /people/match/response`)

## Summary

This pull request adds a new endpoint that allows users to accept or reject friend requests. The `POST /people/match/response` endpoint accepts the requester's user ID and a boolean indicating acceptance or rejection. It updates the friend lists accordingly and manages notifications for both the sender and the recipient.

## Request

**Endpoint:**

```
POST /people/match/response
```

**Headers:**

- **Authorization**: Bearer token obtained after user authentication.

**Request Body:**

```json
{
  "requesterUserId": "60f6c0f5b1d3c72d9c1e4f5a",
  "accept": true
}
```

- **requesterUserId** (string, required): The unique identifier of the user who sent the friend request.
- **accept** (boolean, required): Indicates whether the friend request is accepted (`true`) or rejected (`false`).

## Response

**Success Response (Accepted):**

```json
{
  "status": "success",
  "message": "Friend request accepted."
}
```

**Success Response (Rejected):**

```json
{
  "status": "success",
  "message": "Friend request rejected."
}
```

**Failure Response (Friend Request Not Found):**

```json
{
  "status": "failure",
  "message": "Friend request not found."
}
```